### PR TITLE
Add support for multiple events

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -42,10 +42,10 @@ async function getRiders(
 
   data.forEach((rider) => {
     const { name } = rider;
-    rider.zlteam = name.substring(
+    rider.zlteam = normalizeTeamName(name.substring(
       name.lastIndexOf("(") + 1,
       name.lastIndexOf(")")
-    );
+    ));
     const pos = rider.position_in_cat;
     rider.zlscore = pos < 30 ? individualRiderScores[pos - 1] : 1;
     rider.zlprimespoints = getPrimesPoints(primes, rider.zwid);
@@ -114,12 +114,21 @@ export function toHtml(teams: Team[]): string {
   return `<html lang="en"><head><title>Zwift League</title></head><body>${table}</body></html>`;
 }
 
+function normalizeTeamName(teamName: string) {
+  return teamName.toLowerCase();
+}
+
 export async function getTeamResults(
-  eventId: string,
+  eventIds: string[],
   category: Category
 ): Promise<Team[]> {
-  const primes = await getPrimes(eventId, category);
-  const riders = await getRiders(eventId, category, primes);
+  const riders: Rider[] = [];
+
+  for (const eventId of eventIds) {
+    const primes = await getPrimes(eventId, category);
+    riders.push(...(await getRiders(eventId, category, primes)));
+  }
+
   const teams = getTeams(riders);
 
   return teams;

--- a/server.ts
+++ b/server.ts
@@ -12,12 +12,14 @@ app.use("/teamresults/json", (req, res) => {
   const eventId = req.query.eventId as string;
   const category = req.query.category as Category;
 
+  const eventIds = eventId.split(',');
+
   if (!eventId || !category) {
     res.end("example params: ?eventId=1121811&category=B");
     return;
   }
 
-  getTeamResults(eventId, category).then((result) => {
+  getTeamResults(eventIds, category).then((result) => {
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify(result));
   });
@@ -27,12 +29,14 @@ app.use("/teamresults/html", (req, res) => {
   const eventId = req.query.eventId as string;
   const category = req.query.category as Category;
 
+  const eventIds = eventId.split(',');
+
   if (!eventId || !category) {
     res.end("example params: ?eventId=1121811&category=B");
     return;
   }
 
-  getTeamResults(eventId, category).then((result) => {
+  getTeamResults(eventIds, category).then((result) => {
     res.end(toHtml(result));
   });
 });


### PR DESCRIPTION
Adding a quick way to create a leaderboard for multiple events.

Team points are awared by league/division, not per event. So since the league is still in a "pool" phase, it's important to have a leaderboard with multiple events.
Example:
```
?eventId=1121842,1128468,1128477&category=B
```

Also did normalize the team name, because some names were using capital letters, some others not. But afaik, team tags are not case sensitive.